### PR TITLE
Stop on selection rather than hover, de-ES6ify

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,110 +1,110 @@
-'use strict';
+(function() {
 
-// Determins and sets the timestamp
-class Clock {
+  // Determines and sets the timestamp
+  var unixClock = {
 
-  run() {
-    this.setTimestamp();
-    this.displayTimestamp();
-    this.setInterval();
-  }
+    run: function() {
+      this.setTimestamp();
+      this.displayTimestamp();
+      this.setInterval();
+    },
 
-  setInterval() {
-    const self = this;
-    this.interval = setInterval(function() {
-      self.setTimestamp();
-      self.displayTimestamp();
-    },100);
-  }
+    setInterval: function() {
+      var self = this;
+      this.interval = setInterval(function() {
+        self.setTimestamp();
+        self.displayTimestamp();
+      },100);
+    },
 
-  clearInterval() {
-    if (this.interval) {
-      clearInterval(this.interval);
-      this.interval = null;
+    clearInterval: function() {
+      if (this.interval) {
+        clearInterval(this.interval);
+        this.interval = null;
+      }
+    },
+
+    setTimestamp: function() {
+      this.timestamp = Math.round(+new Date()/1000);
+    },
+
+    displayTimestamp: function() {
+
+      var self = this;
+
+      var setTime = function(timestamp) {
+        $('#timestamp').text(timestamp);
+        document.title = 'Unix Time is ' + timestamp;
+      };
+
+      var displayedNode = $('#timestamp').contents()[0];
+
+      if (!displayedNode) {
+        return setTime(this.timestamp);
+      }
+
+      var selection = window.getSelection();
+
+      if (!selection.isCollapsed && displayedNode === selection.anchorNode) {
+        return;
+      }
+
+      var displayedTime = parseInt(displayedNode.nodeValue);
+      var difference = this.timestamp - displayedTime;
+
+      if (difference < 2) {
+        return setTime(this.timestamp);
+      }
+
+      // Stop counting, let us catch-up
+
+      this.clearInterval();
+
+      for (var i = 0; i < difference; i++) {
+
+        setTimeout(
+          function(step) {
+
+            setTime(displayedTime + step + 1);
+
+            // Done catching up, continue counting
+            if (step === difference - 1) {
+              self.setInterval();
+            }
+
+          }.bind(null, i),
+          i * Math.min(400 / difference, 75)
+        );
+
+      }
+
     }
-  }
 
-  setTimestamp() {
-    this.timestamp = Math.round(+new Date()/1000);
-  }
+  };
 
-  displayTimestamp() {
+  // UI manager, mainly to fullscreen the container
+  var timestampUI = {
 
-    var self = this;
+    setup: function(element) {
+      var self = this;
+      this.fullscreen(element);
+      $(window).resize(function() {
+    		self.fullscreen(element);
+    	});
+    },
 
-    var setTime = function(timestamp) {
-      $('#timestamp').text(timestamp);
-      document.title = 'Unix Time is ' + timestamp;
-    };
-
-    var displayedNode = $('#timestamp').contents()[0];
-
-    if (!displayedNode) {
-      return setTime(this.timestamp);
+    fullscreen: function(element) {
+      return element.css({
+    		height: $(window).height()
+    	});
     }
 
-    var selection = window.getSelection();
+  };
 
-    if (!selection.isCollapsed && displayedNode === selection.anchorNode) {
-      return;
-    }
+  // When ready...
+  $(function(){
+    timestampUI.setup( $('.container') );
+    unixClock.run();
+  });
 
-    var displayedTime = parseInt(displayedNode.nodeValue);
-    var difference = this.timestamp - displayedTime;
-
-    if (difference < 2) {
-      return setTime(this.timestamp);
-    }
-
-    // Stop counting, let us catch-up
-    this.clearInterval();
-
-    for (var i = 0; i < difference; i++) {
-
-      setTimeout(
-        function(step) {
-
-          setTime(displayedTime + step + 1);
-
-          // Done catching up, continue counting
-          if (step === difference - 1) {
-            self.setInterval();
-          }
-
-        }.bind(null, i),
-        i * Math.min(400 / difference, 750)
-      );
-
-    }
-
-  }
-
-}
-
-// UI manager, mainly to fullscreen the container
-class UI {
-
-  setup(element) {
-    const self = this;
-    this.fullscreen(element);
-    $(window).resize(function() {
-  		self.fullscreen(element);
-  	});
-  }
-
-  fullscreen(element) {
-    return element.css({
-  		height: $(window).height()
-  	});
-  }
-
-}
-
-const timestampUI = new UI();
-const unixClock = new Clock();
-
-$(function(){
-
-  timestampUI.setup( $(".container") );
-  unixClock.run();
-});
+})();

--- a/app.js
+++ b/app.js
@@ -14,7 +14,14 @@ class Clock {
     this.interval = setInterval(function() {
       self.setTimestamp();
       self.displayTimestamp();
-    },1000);
+    },100);
+  }
+
+  clearInterval() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
   }
 
   setTimestamp() {
@@ -22,8 +29,54 @@ class Clock {
   }
 
   displayTimestamp() {
-    $('#timestamp').text(this.timestamp);
-    document.title = `Unix Time is ${this.timestamp}`;
+
+    var self = this;
+
+    var setTime = function(timestamp) {
+      $('#timestamp').text(timestamp);
+      document.title = 'Unix Time is ' + timestamp;
+    };
+
+    var displayedNode = $('#timestamp').contents()[0];
+
+    if (!displayedNode) {
+      return setTime(this.timestamp);
+    }
+
+    var selection = window.getSelection();
+
+    if (!selection.isCollapsed && displayedNode === selection.anchorNode) {
+      return;
+    }
+
+    var displayedTime = parseInt(displayedNode.nodeValue);
+    var difference = this.timestamp - displayedTime;
+
+    if (difference < 2) {
+      return setTime(this.timestamp);
+    }
+
+    // Stop counting, let us catch-up
+    this.clearInterval();
+
+    for (var i = 0; i < difference; i++) {
+
+      setTimeout(
+        function(step) {
+
+          setTime(displayedTime + step + 1);
+
+          // Done catching up, continue counting
+          if (step === difference - 1) {
+            self.setInterval();
+          }
+
+        }.bind(null, i),
+        i * Math.min(400 / difference, 750)
+      );
+
+    }
+
   }
 
 }
@@ -53,15 +106,5 @@ const unixClock = new Clock();
 $(function(){
 
   timestampUI.setup( $(".container") );
-
   unixClock.run();
-
-  $('#timestamp').mouseenter(function() {
-    clearInterval(unixClock.interval);
-  });
-
-  $('#timestamp').mouseleave(function() {
-    unixClock.run();
-  });
-
 });


### PR DESCRIPTION
Now when the timer stops when the text is selected rather than when it is hovered.  When the text is deselected, the timer quickly catches back up to the current time.

I also de-ES6ified the code so that it works across browsers.  And wrapped the app.js code in a closure.  I suggest checking out the diff ignoring whitespace changes: https://github.com/maxatbrs/unixtimestampme/pull/2/files?w=1
